### PR TITLE
Do not raise exception when deleting non-existent files

### DIFF
--- a/src/ch/enterag/utils/zip/Zip64File.java
+++ b/src/ch/enterag/utils/zip/Zip64File.java
@@ -1187,7 +1187,7 @@ public class Zip64File
   /*------------------------------------------------------------------*/
   /** deletes the ZIP file entry.
   @param sEntryName name of file entry to be deleted.
-  @return deleted file entry.
+  @return deleted file entry or null, if the file did not exist
   @throws IOException if an I/O error occurred.
   */
   public FileEntry delete(String sEntryName)
@@ -1225,8 +1225,6 @@ public class Zip64File
 	  	m_listFileEntries.remove(feDelete);
 	  	m_mapFileEntries.remove(feDelete.getName());
   	}
-  	else
-  		throw new ZipException("File "+sEntryName+" cannot be deleted, because it does not exist!");
   	return feDelete;
   } /* delete */
   

--- a/test/ch/enterag/utils/zip/Zip64FileTester.java
+++ b/test/ch/enterag/utils/zip/Zip64FileTester.java
@@ -961,6 +961,7 @@ public class Zip64FileTester extends TestCase
 		{
 			Zip64File zf = new Zip64File(m_sTestZipFile);
 			zf.delete("many/small12345.txt");
+			FileEntry nonExistentDel = zf.delete("non-existent");
 			zf.close();
 			if (!extractFile("many/small12344.txt"))
 				fail("many/small12344.txt could not be extracted!");
@@ -972,6 +973,8 @@ public class Zip64FileTester extends TestCase
 				fail("many/small12346.txt could not be extracted!");
 			if (!equalTest(fileSmall12346,fileSmall12346Original))
 				fail("extracted compressed small12346 file is not equal to its original!");
+			if (nonExistentDel != null)
+				fail("deleting a non-existent file should return null!");
 		}
 		catch(FileNotFoundException fnfe) { fail(fnfe.getClass().getName()+": "+fnfe.getMessage());}
 		catch(IOException ie) { fail(ie.getClass().getName()+": "+ie.getMessage());}


### PR DESCRIPTION
This PR makes the `Zip64File.delete()` method return null instead of raising a ZipException when deleting a non-existent file entry. This is consistent with the `getFileEntry()` method in the same class that returns null when a non-existent file entry is requested.

---

Without this change this can happen:

1. SiardGui is used to edit a SIARD file that does not contain a `header/metadata.xsl` file (which is optional as per the specification).
2. When saving changes SiardGui calls the `ArchiveImpl.saveMetaData()` method from SiardApi.
3. This method calls the `Zip64File.delete()` method trying to delete the `header/metadata.xsl` file.
4. A ZipException is raised and this execption is thrown at the irritated end user in the shape of an error message. Not pretty.

If null is returned instead of raising an exception nothing happens because the return value of the `delete()` method is ignored anyway.

PS: I added a test case for this behaviour but it seems the tests in the `Zip64FileTester` are not run. Maybe I'm doing something wrong, so you better double check this ...